### PR TITLE
Add validation feature

### DIFF
--- a/src/Sinter/Core/IPropertyValidator.cs
+++ b/src/Sinter/Core/IPropertyValidator.cs
@@ -1,0 +1,8 @@
+using Sinter.Validations;
+
+namespace Sinter.Core;
+
+public interface IPropertyValidator<TRequest>
+{
+    Task<ValidationError?> ValidateAsync(TRequest request, CancellationToken cancellationToken);
+}

--- a/src/Sinter/Core/IRuleBuilder.cs
+++ b/src/Sinter/Core/IRuleBuilder.cs
@@ -1,0 +1,27 @@
+namespace Sinter.Core;
+
+public interface IRuleBuilder<TRequest, TProperty>
+{
+    IRuleBuilder<TRequest, TProperty> WithMessage(string errorMessage);
+    IRuleBuilder<TRequest, TProperty> When(Func<TRequest, bool> condition);
+    IRuleBuilder<TRequest, TProperty> Unless(Func<TRequest, bool> condition);
+
+    IRuleBuilder<TRequest, TProperty> NotNull();
+    IRuleBuilder<TRequest, TProperty> NotEmpty();
+    IRuleBuilder<TRequest, TProperty> Required();
+    IRuleBuilder<TRequest, TProperty> Length(int minLength, int maxLength);
+    IRuleBuilder<TRequest, TProperty> MinLength(int minLength);
+    IRuleBuilder<TRequest, TProperty> MaxLength(int maxLength);
+    IRuleBuilder<TRequest, TProperty> GreaterThan(TProperty value);
+    IRuleBuilder<TRequest, TProperty> GreaterThanOrEqual(TProperty value);
+    IRuleBuilder<TRequest, TProperty> LessThan(TProperty value);
+    IRuleBuilder<TRequest, TProperty> LessThanOrEqual(TProperty value);
+    IRuleBuilder<TRequest, TProperty> Range(TProperty min, TProperty max);
+    IRuleBuilder<TRequest, TProperty> Email();
+    IRuleBuilder<TRequest, TProperty> Matches(string pattern);
+    IRuleBuilder<TRequest, TProperty> Equals(TProperty value);
+    IRuleBuilder<TRequest, TProperty> NotEquals(TProperty value);
+
+    IRuleBuilder<TRequest, TProperty> Must(Func<TProperty, bool> predicate);
+    IRuleBuilder<TRequest, TProperty> MustAsync(Func<TProperty, CancellationToken, Task<bool>> predicate);
+}

--- a/src/Sinter/Core/IValidationHandler.cs
+++ b/src/Sinter/Core/IValidationHandler.cs
@@ -1,0 +1,6 @@
+namespace Sinter.Core;
+
+public interface IValidationHandler
+{
+    Task ValidateAsync(object request, CancellationToken cancellationToken);
+}

--- a/src/Sinter/Core/IValidator.cs
+++ b/src/Sinter/Core/IValidator.cs
@@ -1,0 +1,9 @@
+
+using Sinter.Validations;
+
+namespace Sinter.Core;
+
+public interface IValidator<in TRequest>
+{
+    Task<ValidationResult> ValidateAsync(TRequest request, CancellationToken cancellationToken = default);
+}

--- a/src/Sinter/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Sinter/DependencyInjection/ServiceCollectionExtensions.cs
@@ -11,7 +11,7 @@ public static class ServiceCollectionExtensions
     {
         return services.AddSinter(Assembly.GetCallingAssembly());
     }
-    
+
     public static IServiceCollection AddSinter(this IServiceCollection services, params Assembly[] assemblies)
     {
         services.TryAddScoped<IDispatcher, Dispatcher>();
@@ -35,5 +35,24 @@ public static class ServiceCollectionExtensions
         {
             services.TryAddScoped(handler.InterfaceType, handler.ImplementationType);
         }
+    }
+
+    public static IServiceCollection AddSinterValidators(this IServiceCollection services, params Assembly[] assemblies)
+    {
+        foreach (var assembly in assemblies)
+        {
+            var validatorTypes = assembly.GetTypes()
+                                         .Where(t => t.IsClass && !t.IsAbstract && !t.IsGenericTypeDefinition)
+                                         .SelectMany(t => t.GetInterfaces()
+                                                           .Where(i => i.GetGenericTypeDefinition() == typeof(IValidator<>))
+                                                           .Select(i => new { ValidatorType = t, Interface = i }));
+
+            foreach (var validatorType in validatorTypes)
+            {
+                services.AddScoped(validatorType.Interface, validatorType.ValidatorType);
+            }
+        }
+
+        return services;
     }
 }

--- a/src/Sinter/Exceptions/ValidationException.cs
+++ b/src/Sinter/Exceptions/ValidationException.cs
@@ -1,0 +1,17 @@
+using Sinter.Validations;
+
+namespace Sinter.Exceptions;
+
+public class ValidationException : Exception
+{
+    public ValidationResult ValidationResult { get; }
+
+    public ValidationException(ValidationResult validationResult) : base("Validation failed")
+    {
+        ValidationResult = validationResult ?? throw new ArgumentNullException(nameof(validationResult));
+    }
+    
+    public ValidationException(string propertyName, string errorMessage) : this(ValidationResult.Failure(propertyName, errorMessage))
+    {
+    }
+}

--- a/src/Sinter/Sinter.csproj
+++ b/src/Sinter/Sinter.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>Sinter</PackageId>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Authors>Nguyen Huu Duy Hoang</Authors>
     <Product>Sinter</Product>
     <Description>A simple mediator pattern implementation for CQRS in .NET applications.</Description>

--- a/src/Sinter/Validations/AbstractValidator.cs
+++ b/src/Sinter/Validations/AbstractValidator.cs
@@ -1,0 +1,46 @@
+using System.Linq.Expressions;
+using Sinter.Core;
+
+namespace Sinter.Validations;
+
+public abstract class AbstractValidator<TRequest> : IValidator<TRequest>
+{
+    public readonly List<IPropertyValidator<TRequest>> _rules = [];
+
+    public virtual async Task<ValidationResult> ValidateAsync(TRequest request, CancellationToken cancellationToken = default)
+    {
+		List<ValidationError> errors = [];
+
+        foreach (var rule in _rules)
+        {
+            var error = await rule.ValidateAsync(request, cancellationToken);
+
+            if (error is not null)
+            {
+                errors.Add(error);
+            }
+		}
+
+        return new ValidationResult(errors);
+	}
+
+    protected IRuleBuilder<TRequest, TProperty> RuleFor<TProperty>(
+        Expression<Func<TRequest, TProperty>> propertyExpression)
+    {
+        var validator = new PropertyValidator<TRequest, TProperty>(propertyExpression);
+        _rules.Add(validator);
+
+        var propertyName = GetPropertyName(propertyExpression);
+        return new RuleBuilder<TRequest, TProperty>(validator, propertyName);
+    }
+
+    private static string GetPropertyName<TProperty>(Expression<Func<TRequest, TProperty>> expression)
+    {
+        if (expression.Body is MemberExpression memberExpression)
+        {
+            return memberExpression.Member.Name;
+        }
+
+        throw new ArgumentException("Expression must be a member expression");
+    }
+}

--- a/src/Sinter/Validations/PropertyValidator.cs
+++ b/src/Sinter/Validations/PropertyValidator.cs
@@ -1,0 +1,114 @@
+using System.Linq.Expressions;
+using Sinter.Core;
+
+namespace Sinter.Validations;
+
+public class PropertyValidator<TRequest, TProperty> : IPropertyValidator<TRequest>
+{
+    private readonly Func<TRequest, TProperty> _propertyAccessor;
+    private readonly string _propertyName;
+    private readonly List<Validator> _validators = [];
+    private Func<TRequest, bool>? _condition;
+
+    public PropertyValidator(Expression<Func<TRequest, TProperty>> propertyExpression)
+    {
+        _propertyAccessor = propertyExpression.Compile();
+        _propertyName = GetPropertyName(propertyExpression);
+    }
+
+    public async Task<ValidationError?> ValidateAsync(TRequest request, CancellationToken cancellationToken)
+    {
+        if (_condition is not null && !_condition(request))
+        {
+            return null;
+        }
+
+        var propertyValue = _propertyAccessor(request);
+
+        foreach (var validator in _validators)
+        {
+            bool isValid;
+
+            if (validator.IsAsync)
+            {
+                isValid = await validator.AsyncPredicates!(propertyValue, cancellationToken);
+            }
+            else
+            {
+                isValid = validator.SyncPredicates!(propertyValue);
+            }
+
+            if (!isValid)
+            {
+                return new ValidationError(_propertyName, validator.ErrorMessage);
+            }
+        }
+
+        return null;
+    }
+
+    public PropertyValidator<TRequest, TProperty> SetCondition(Func<TRequest, bool> condition)
+    {
+        _condition = condition;
+        return this;
+    }
+
+    public PropertyValidator<TRequest, TProperty> AddValidator(
+        Func<TProperty, bool> predicate,
+        string errorMessage)
+    {
+        _validators.Add(new Validator
+        {
+            SyncPredicates = predicate,
+            ErrorMessage = errorMessage,
+            IsAsync = false
+        });
+
+        return this;
+    }
+
+    public PropertyValidator<TRequest, TProperty> AddAsyncValidator(
+        Func<TProperty, CancellationToken, Task<bool>> asyncPredicate,
+        string errorMessage)
+    {
+        _validators.Add(new Validator
+        {
+            AsyncPredicates = asyncPredicate,
+            ErrorMessage = errorMessage,
+            IsAsync = true
+        });
+
+        return this;
+    }
+
+    public PropertyValidator<TRequest, TProperty> UpdateLastMessage(string errorMessage)
+    {
+        if (_validators.Count > 0)
+        {
+            _validators[^1].ErrorMessage = errorMessage;
+        }
+
+        return this;
+    }
+
+    private static string GetPropertyName(Expression<Func<TRequest, TProperty>> expression)
+    {
+        if (expression.Body is MemberExpression memberExpression)
+        {
+            return memberExpression.Member.Name;
+        }
+
+        throw new ArgumentException("Expression must be a member expression");
+    }
+
+    private class Validator
+    {
+        public Func<TProperty, bool>? SyncPredicates { get; set; }
+
+        public Func<TProperty, CancellationToken, Task<bool>>? AsyncPredicates { get; set; }
+
+        public string ErrorMessage { get; set; } = string.Empty;
+
+        public bool IsAsync { get; set; }
+    }
+}

--- a/src/Sinter/Validations/RuleBuilder.cs
+++ b/src/Sinter/Validations/RuleBuilder.cs
@@ -1,0 +1,227 @@
+using System.Collections;
+using Sinter.Core;
+
+namespace Sinter.Validations;
+
+public class RuleBuilder<TRequest, TProperty> : IRuleBuilder<TRequest, TProperty>
+{
+    private readonly PropertyValidator<TRequest, TProperty> _propertyValidator;
+    private readonly string _propertyName;
+
+    public RuleBuilder(PropertyValidator<TRequest, TProperty> propertyValidator, string propertyName)
+    {
+        _propertyValidator = propertyValidator;
+        _propertyName = propertyName;
+    }
+
+    public IRuleBuilder<TRequest, TProperty> WithMessage(string errorMessage)
+    {
+        _propertyValidator.UpdateLastMessage(errorMessage);
+        return this;
+    }
+
+    public IRuleBuilder<TRequest, TProperty> When(Func<TRequest, bool> condition)
+    {
+        _propertyValidator.SetCondition(condition);
+        return this;
+    }
+
+    public IRuleBuilder<TRequest, TProperty> Unless(Func<TRequest, bool> condition)
+    {
+        _propertyValidator.SetCondition(request => !condition(request));
+        return this;
+    }
+
+    public IRuleBuilder<TRequest, TProperty> NotNull()
+    {
+        _propertyValidator.AddValidator(
+            value => value is not null,
+            $"{_propertyName} must not be null.");
+
+        return this;
+    }
+
+    public IRuleBuilder<TRequest, TProperty> NotEmpty()
+    {
+        _propertyValidator.AddValidator(value =>
+        {
+            return value switch
+            {
+                null => false,
+                string str => !string.IsNullOrEmpty(str),
+                IEnumerable enumerable => enumerable.Cast<object>().Any(),
+                _ => true
+            };
+        }, $"{_propertyName} must not be empty.");
+
+        return this;
+    }
+
+    public IRuleBuilder<TRequest, TProperty> Required()
+    {
+        _propertyValidator.AddValidator(value =>
+        {
+            return value switch
+            {
+                null => false,
+                string str => !string.IsNullOrWhiteSpace(str),
+                _ => true
+            };
+        }, $"{_propertyName} is required.");
+
+        return this;
+    }
+
+    public IRuleBuilder<TRequest, TProperty> Length(int minLength, int maxLength)
+    {
+        _propertyValidator.AddValidator(
+            value => value is string str && ValidationRules.Length(str, minLength, maxLength),
+            $"{_propertyName} must be between {minLength} and {maxLength} characters."
+        );
+
+        return this;
+    }
+
+    public IRuleBuilder<TRequest, TProperty> MinLength(int minLength)
+    {
+        _propertyValidator.AddValidator(
+            value => value is string str && ValidationRules.MinLength(str, minLength),
+            $"{_propertyName} must be at least {minLength} characters."
+        );
+
+        return this;
+    }
+
+    public IRuleBuilder<TRequest, TProperty> MaxLength(int maxLength)
+    {
+        _propertyValidator.AddValidator(
+            value => value is not string str || ValidationRules.MaxLength(str, maxLength),
+            $"{_propertyName} must not exceed {maxLength} characters."
+        );
+
+        return this;
+    }
+
+    public IRuleBuilder<TRequest, TProperty> GreaterThan(TProperty value)
+    {
+        _propertyValidator.AddValidator(prop =>
+        {
+            if (prop is IComparable<TProperty> comparable)
+            {
+                return comparable.CompareTo(value) > 0;
+            }
+
+			return false;
+		}, $"{_propertyName} must be greater than {value}.");
+
+        return this;
+    }
+
+    public IRuleBuilder<TRequest, TProperty> GreaterThanOrEqual(TProperty value)
+    {
+        _propertyValidator.AddValidator(prop =>
+        {
+            if (prop is IComparable<TProperty> comparable)
+            {
+                return comparable.CompareTo(value) >= 0;
+            }
+
+            return false;
+        }, $"{_propertyName} must be greater than or equal to {value}.");
+
+        return this;
+    }
+
+    public IRuleBuilder<TRequest, TProperty> LessThan(TProperty value)
+    {
+        _propertyValidator.AddValidator(prop =>
+        {
+            if (prop is IComparable<TProperty> comparable)
+            {
+                return comparable.CompareTo(value) < 0;
+            }
+
+            return false;
+        }, $"{_propertyName} must be less than {value}.");
+
+        return this;
+    }
+
+    public IRuleBuilder<TRequest, TProperty> LessThanOrEqual(TProperty value)
+    {
+        _propertyValidator.AddValidator(prop =>
+        {
+            if (prop is IComparable<TProperty> comparable)
+            {
+                return comparable.CompareTo(value) <= 0;
+            }
+
+            return false;
+        }, $"{_propertyName} must be less than or equal to{value}.");
+
+        return this;
+    }
+
+    public IRuleBuilder<TRequest, TProperty> Range(TProperty min, TProperty max)
+    {
+        _propertyValidator.AddValidator(prop =>
+        {
+            if (prop is IComparable<TProperty> comparable)
+            {
+                return comparable.CompareTo(min) >= 0 && comparable.CompareTo(max) <= 0;
+            }
+
+            return false;
+        }, $"{_propertyName} must be between {min} and {max}");
+
+        return this;
+    }
+
+    public IRuleBuilder<TRequest, TProperty> Email()
+    {
+        _propertyValidator.AddValidator(
+            value => value is string str && ValidationRules.IsEmail(str),
+            $"{_propertyName} must be a valid email address");
+
+        return this;
+    }
+
+    public IRuleBuilder<TRequest, TProperty> Matches(string pattern)
+    {
+        _propertyValidator.AddValidator(
+            value => value is string str && ValidationRules.Matches(str, pattern),
+            $"{_propertyName} is not in the correct format");
+
+        return this;
+    }
+
+    public IRuleBuilder<TRequest, TProperty> Equals(TProperty value)
+    {
+        _propertyValidator.AddValidator(
+            prop => EqualityComparer<TProperty>.Default.Equals(prop, value),
+            $"{_propertyName} must equal to {value}");
+
+        return this;
+    }
+
+    public IRuleBuilder<TRequest, TProperty> NotEquals(TProperty value)
+    {
+        _propertyValidator.AddValidator(
+            prop => !EqualityComparer<TProperty>.Default.Equals(value),
+            $"{_propertyName} must not equal to {value}");
+
+        return this;
+    }
+
+    public IRuleBuilder<TRequest, TProperty> Must(Func<TProperty, bool> predicate)
+    {
+        _propertyValidator.AddValidator(predicate, $"{_propertyName} is invalid");
+        return this;
+    }
+
+    public IRuleBuilder<TRequest, TProperty> MustAsync(Func<TProperty, CancellationToken, Task<bool>> predicate)
+    {
+        _propertyValidator.AddAsyncValidator(predicate, $"{_propertyName} is invalid");
+        return this;
+    }
+}

--- a/src/Sinter/Validations/ValidationError.cs
+++ b/src/Sinter/Validations/ValidationError.cs
@@ -1,0 +1,17 @@
+namespace Sinter.Validations;
+
+/// <summary>
+/// Represent a single validation error
+/// </summary>
+public sealed class ValidationError
+{
+    public string PropertyName { get; set; }
+
+    public string ErrorMessage { get; set; }
+
+    public ValidationError(string propertyName, string errorMessage)
+    {
+        PropertyName = propertyName ?? throw new ArgumentNullException(nameof(propertyName));
+        ErrorMessage = errorMessage ?? throw new ArgumentNullException(nameof(errorMessage));
+    }
+}

--- a/src/Sinter/Validations/ValidationHandler.cs
+++ b/src/Sinter/Validations/ValidationHandler.cs
@@ -1,0 +1,46 @@
+using Sinter.Core;
+using Sinter.Exceptions;
+
+namespace Sinter.Validations;
+
+public class ValidationHandler<TRequest> : IValidationHandler
+{
+    private readonly IEnumerable<IValidator<TRequest>> _validators;
+    private readonly ValidationOptions _options;
+
+    public ValidationHandler(IEnumerable<IValidator<TRequest>> validators, ValidationOptions options)
+    {
+        _validators = validators;
+        _options = options;
+    }
+
+    public async Task ValidateAsync(object request, CancellationToken cancellationToken)
+    {
+        if (request is not TRequest typedRequest)
+        {
+            return;
+        }
+
+        List<ValidationError> errors = [];
+
+        foreach (var validator in _validators)
+        {
+            var result = await validator.ValidateAsync(typedRequest, cancellationToken);
+
+            if (!result.IsValid)
+            {
+                errors.AddRange(result.Errors);
+
+                if (!_options.RunAllValidators && !_options.ThrowOnValidationFailure)
+                {
+                    break;
+                }
+            }
+        }
+
+        if (errors.Count > 0 && _options.ThrowOnValidationFailure)
+        {
+            throw new ValidationException(new ValidationResult(errors));
+        }
+    }
+}

--- a/src/Sinter/Validations/ValidationOptions.cs
+++ b/src/Sinter/Validations/ValidationOptions.cs
@@ -1,0 +1,17 @@
+namespace Sinter.Validations;
+
+/// <summary>
+/// Options for validator behaviors
+/// </summary>
+public class ValidationOptions
+{
+    /// <summary>
+    /// Whether to throw ValidationException on validation failure. Default is true
+    /// </summary>
+    public bool ThrowOnValidationFailure { get; set; } = true;
+
+    /// <summary>
+    /// Whether to run all validators even if one failes. Default is false
+    /// </summary>
+    public bool RunAllValidators { get; set; } = false;
+}

--- a/src/Sinter/Validations/ValidationResult.cs
+++ b/src/Sinter/Validations/ValidationResult.cs
@@ -1,0 +1,27 @@
+namespace Sinter.Validations;
+
+/// <summary>
+/// Represents a validation result
+/// </summary>
+public sealed class ValidationResult
+{
+    public bool IsValid { get; }
+
+    public IReadOnlyList<ValidationError> Errors { get; }
+
+    public ValidationResult(IEnumerable<ValidationError> errors)
+    {
+        List<ValidationError> errorList = errors?.ToList() ?? [];
+        Errors = errorList.AsReadOnly();
+        IsValid = errorList.Count == 0;
+    }
+
+    public static ValidationResult Success => new([]);
+
+    public static ValidationResult Failure(params ValidationError[] errors) => new(errors);
+
+    public static ValidationResult Failure(string propertyName, string errorMessage)
+    {
+        return new ValidationResult([new ValidationError(propertyName, errorMessage)]);
+    }
+}

--- a/src/Sinter/Validations/ValidationRules.cs
+++ b/src/Sinter/Validations/ValidationRules.cs
@@ -1,0 +1,46 @@
+using System.Text.RegularExpressions;
+
+namespace Sinter.Validations;
+
+/// <summary>
+/// Built-in validation rules
+/// </summary>
+public static class ValidationRules
+{
+    public static bool Length(string value, int minLength, int maxLength)
+    => value is not null && value.Length >= minLength && value.Length <= maxLength;
+
+    public static bool MinLength(string value, int minLength)
+    => value is not null && value.Length >= minLength;
+
+    public static bool MaxLength(string value, int maxLength)
+    => value is not null && value.Length <= maxLength;
+
+    public static bool IsEmail(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var atIndex = value.IndexOf('@');
+
+        if (atIndex <= 0 || atIndex == value.Length - 1)
+        {
+            return false;
+        }
+
+        var dotIndex = value.LastIndexOf('.');
+        return dotIndex > atIndex + 1 && dotIndex < value.Length - 1;
+    }
+
+    public static bool Matches(string value, string pattern)
+    {
+        if (value is null)
+        {
+            return false;
+        }
+
+        return Regex.IsMatch(value, pattern);
+    }
+}

--- a/tests/Sinter.Tests/Integrations/IntegrationTests.cs
+++ b/tests/Sinter.Tests/Integrations/IntegrationTests.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Sinter.Core;
 using Sinter.DependencyInjection;
 
-namespace Sinter.Tests;
+namespace Sinter.Tests.Integrations;
 
 public class IntegrationTests
 {

--- a/tests/Sinter.Tests/Units/AbstractValidatorTests.cs
+++ b/tests/Sinter.Tests/Units/AbstractValidatorTests.cs
@@ -1,0 +1,92 @@
+﻿using FluentAssertions;
+using Sinter.Validations;
+
+namespace Sinter.Tests.Units;
+public class AbstractValidatorTests
+{
+	private class TestRequest
+	{
+		public string FirstName { get; set; }
+
+		public string LastName { get; set; }
+
+		public string Email { get; set; }
+
+		public int Age { get; set; }
+	}
+
+	private class EmptyValidator : AbstractValidator<TestRequest>
+	{
+	}
+
+	private class ComplexValidator : AbstractValidator<TestRequest>
+	{
+		public ComplexValidator()
+		{
+			RuleFor(x => x.FirstName).Required();
+			RuleFor(x => x.LastName).Required();
+			RuleFor(x => x.Email).Email();
+			RuleFor(x => x.Age).GreaterThan(0);
+		}
+	}
+
+	[Fact]
+	public async Task ValidateAsync_WithNoRules_ShouldReturnValid()
+	{
+		// Arrange
+		var validator = new EmptyValidator();
+		var request = new TestRequest();
+
+		// Act
+		var result = await validator.ValidateAsync(request);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+		result.Errors.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task ValidateAsync_WithAllRulesPassing_ShouldReturnValid()
+	{
+		// Arrange
+		var validator = new ComplexValidator();
+		var request = new TestRequest
+		{
+			FirstName = "John",
+			LastName = "Doe",
+			Email = "john@example.com",
+			Age = 30
+		};
+
+		// Act
+		var result = await validator.ValidateAsync(request);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+		result.Errors.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task ValidateAsync_WithMultipleFailingRules_ShouldReturnAllErrors()
+	{
+		// Arrange
+		var validator = new ComplexValidator();
+		var request = new TestRequest
+		{
+			FirstName = "",
+			LastName = null,
+			Email = "invalid",
+			Age = -1
+		};
+
+		// Act
+		var result = await validator.ValidateAsync(request);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().HaveCount(4);
+		result.Errors.Select(e => e.PropertyName)
+					 .Should()
+					 .Contain(["FirstName", "LastName", "Email", "Age"]);
+	}
+}

--- a/tests/Sinter.Tests/Units/PropertyValidatorTests.cs
+++ b/tests/Sinter.Tests/Units/PropertyValidatorTests.cs
@@ -1,0 +1,132 @@
+﻿using FluentAssertions;
+using Sinter.Validations;
+using System.Linq.Expressions;
+
+namespace Sinter.Tests.Units;
+public class PropertyValidatorTests
+{
+	private class TestRequest
+	{
+		public string Username { get; set; }
+
+		public int Age { get; set; }
+
+		public string Email { get; set; }
+	}
+
+	[Fact]
+	public async Task ValidateAsync_WithValidValue_ShouldReturnNull()
+	{
+		// Arrange
+		Expression<Func<TestRequest, string>> propertyExpression = x => x.Username;
+		var validator = new PropertyValidator<TestRequest, string>(propertyExpression);
+		validator.AddValidator(value => !string.IsNullOrEmpty(value), "Username is required");
+
+		var request = new TestRequest { Username = "validUser" };
+
+		// Act
+		var result = await validator.ValidateAsync(request, CancellationToken.None);
+
+		// Assert
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task ValidateAsync_WithInvalidValue_ShouldReturnError()
+	{
+		// Arrange
+		Expression<Func<TestRequest, string>> propertyExpression = x => x.Username;
+		var validator = new PropertyValidator<TestRequest, string>(propertyExpression);
+		validator.AddValidator(value => !string.IsNullOrEmpty(value), "Username is required");
+
+		var request = new TestRequest { Username = string.Empty };
+
+		// Act
+		var result = await validator.ValidateAsync(request, CancellationToken.None);
+
+		// Assert
+		result.Should().NotBeNull();
+		result.PropertyName.Should().Be("Username");
+		result.ErrorMessage.Should().Be("Username is required");
+	}
+
+	[Fact]
+	public async Task ValidateAsync_WithMultipleValidators_ShouldStopOnFirstError()
+	{
+		// Arrange
+		Expression<Func<TestRequest, string>> propertyExpression = x => x.Username;
+		var validator = new PropertyValidator<TestRequest, string>(propertyExpression);
+		validator.AddValidator(value => !string.IsNullOrEmpty(value), "Username is required");
+		validator.AddValidator(value => value.Length >= 3, "Username must be at least 3 characters");
+
+		var request = new TestRequest { Username = string.Empty };
+
+		// Act
+		var result = await validator.ValidateAsync(request, CancellationToken.None);
+
+		// Assert
+		result.Should().NotBeNull();
+		result.ErrorMessage.Should().Be("Username is required");
+	}
+
+	[Fact]	
+	public async Task ValidateAsync_WithCondition_WhenConditionMet_ShouldValidate()
+	{
+		// Arrange
+		Expression<Func<TestRequest, string>> propertyExpression = x => x.Email;
+		var validator = new PropertyValidator<TestRequest, string>(propertyExpression);
+		validator.SetCondition(request => request.Age >= 18);
+		validator.AddValidator(value => value.Contains('@') == true, "Email is invalid");
+
+		var request = new TestRequest { Age = 20, Email = "invalid" };
+
+		// Act
+		var result = await validator.ValidateAsync(request, CancellationToken.None);
+
+		// Assert
+		result.Should().NotBeNull();
+		result.PropertyName.Should().Be("Email is invalid");
+	}
+
+	[Fact]
+	public async Task ValidateAsync_WithCondition_WhenConditionNotMet_ShouldSkipValidation()
+	{
+		// Arrange
+		Expression<Func<TestRequest, string>> propertyExpression = x => x.Email;
+		var validator = new PropertyValidator<TestRequest, string>(propertyExpression);
+		validator.SetCondition(request => request.Age >= 18);
+		validator.AddValidator(value => value.Contains('@') == true, "Email is invalid");
+
+		var request = new TestRequest { Age = 16, Email = "invalid" };
+
+		// Act
+		var result = await validator.ValidateAsync(request, CancellationToken.None);
+
+		// Assert
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public async Task ValidateAsync_WithAsyncValidator_ShouldWork()
+	{
+		// Arrange
+		Expression<Func<TestRequest, string>> propertyExpression = x => x.Username;
+		var validator = new PropertyValidator<TestRequest, string>(propertyExpression);
+		validator.AddAsyncValidator(
+			async (value, cancellationToken) =>
+			{
+				await Task.Delay(10, cancellationToken);
+				return value != "admin";
+			},
+			"Username already exists");
+
+		var request = new TestRequest { Username = "admin" };
+
+		// Act
+		var result = await validator.ValidateAsync(request, CancellationToken.None);
+
+		// Assert
+		result.Should().NotBeNull();
+		result.PropertyName.Should().Be("Username already exists");
+	}
+}

--- a/tests/Sinter.Tests/Units/RuleBuilderTests.cs
+++ b/tests/Sinter.Tests/Units/RuleBuilderTests.cs
@@ -1,0 +1,146 @@
+﻿using FluentAssertions;
+using Sinter.Validations;
+
+namespace Sinter.Tests.Units;
+public class RuleBuilderTests
+{
+	private class TestRequest
+	{
+		public string Name { get; set; }
+
+		public string Email { get; set; }
+
+		public int Age { get; set; }
+
+		public string Password { get; set; }
+	}
+
+	private class TestValidator : AbstractValidator<TestRequest>
+	{
+		public TestValidator()
+		{
+			RuleFor(x => x.Name).Required()
+								.MinLength(3)
+								.WithMessage("Name must be at least 3 characters");
+
+			RuleFor(x => x.Email).Required()
+								 .Email()
+								 .When(x => x.Age >= 18);
+
+			RuleFor(x => x.Age).GreaterThanOrEqual(0)
+							   .LessThan(150);
+
+			RuleFor(x => x.Password).MinLength(8)
+									.Matches(@"^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)")
+									.WithMessage("Password must contain upper case, lower case and number")
+									.Unless(x => string.IsNullOrEmpty(x.Password));
+		}
+	}
+
+	[Fact]
+	public async Task RuleBuilder_WithValidRequest_ShouldPassValidation()
+	{
+		// Arrange
+		var validator = new TestValidator();
+		var request = new TestRequest
+		{
+			Name = "John Doe",
+			Email = "john@example.com",
+			Age = 25,
+			Password = "Pass123"
+		};
+
+		// Act
+		var result = await validator.ValidateAsync(request);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+		result.Errors.Should().BeEmpty();
+	}
+
+	[Fact]
+	public async Task RuleBuilder_WithMultipleErrors_ShouldReturnAllErrors()
+	{
+		// Arrange
+		var validator = new TestValidator();
+		var request = new TestRequest
+		{
+			Name = "Jo",
+			Email = "invalid",
+			Age = 25,
+			Password = "weak"
+		};
+
+		// Act
+		var result = await validator.ValidateAsync(request);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().HaveCount(3);
+		result.Errors.Should().Contain(e => e.PropertyName == "Name");
+		result.Errors.Should().Contain(e => e.PropertyName == "Email");
+		result.Errors.Should().Contain(e => e.PropertyName == "Password");
+	}
+
+	[Fact]
+	public async Task RuleBuilder_WithCustomMessage_ShouldUseCustomMessage()
+	{
+		// Arrange
+		var validator = new TestValidator();
+		var request = new TestRequest
+		{
+			Name = "Jo",
+			Email = "test@example.com",
+			Age = 25,
+			Password = "Pass123"
+		};
+
+		// Act
+		var result = await validator.ValidateAsync(request);
+
+		// Assert
+		result.IsValid.Should().BeFalse();
+		result.Errors.Should().HaveCount(1);
+		result.Errors[0].ErrorMessage.Should().Be("Name must be at least 3 characters");
+	}
+
+	[Fact]
+	public async Task RuleBuilder_WithCondition_ShouldOnlyValidateWhenConditionMet()
+	{
+		// Arrange
+		var validator = new TestValidator();
+		var request = new TestRequest
+		{
+			Name = "John",
+			Email = "invalid",
+			Age = 16,
+			Password = "Pass123"
+		};
+
+		// Act
+		var result = await validator.ValidateAsync(request);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task RuleBuilder_WithUnless_ShouldSkipWhenConditionMet()
+	{
+		// Arrange
+		var validator = new TestValidator();
+		var request = new TestRequest
+		{
+			Name = "John",
+			Email = "test@example.com",
+			Age = 25,
+			Password = ""
+		};
+
+		// Act
+		var result = await validator.ValidateAsync(request);
+
+		// Assert
+		result.IsValid.Should().BeTrue();
+	}
+}

--- a/tests/Sinter.Tests/Units/ValidationErrorTests.cs
+++ b/tests/Sinter.Tests/Units/ValidationErrorTests.cs
@@ -1,0 +1,35 @@
+﻿using FluentAssertions;
+using Sinter.Validations;
+
+namespace Sinter.Tests.Units;
+public class ValidationErrorTests
+{
+	[Fact]
+	public void Constructor_WithValidParameters_ShouldCreateError()
+	{
+		// Act
+		var error = new ValidationError("Username", "Username is required");
+
+		// Assert
+		error.PropertyName.Should().Be("Username");
+		error.ErrorMessage.Should().Be("Username is required");
+	}
+
+	[Fact]
+	public void Constructor_WithNullPropertyName_ShouldThrow()
+	{
+		// Act
+		var act = () => new ValidationError(null!, "Error message");
+		act.Should().Throw<ArgumentNullException>()
+			.WithParameterName("propertyName");
+	}
+
+	[Fact]
+	public void Constructor_WithNullErrorMessage_ShouldThrow()
+	{
+		// Act
+		var act = () => new ValidationError("Property", null!);
+		act.Should().Throw<ArgumentNullException>()
+			.WithParameterName("errorMessage");
+	}
+}

--- a/tests/Sinter.Tests/Units/ValidationResultTests.cs
+++ b/tests/Sinter.Tests/Units/ValidationResultTests.cs
@@ -1,0 +1,75 @@
+using FluentAssertions;
+using Sinter.Validations;
+
+namespace Sinter.Tests.Units;
+
+public class ValidationResultTests
+{
+    [Fact]
+    public void Success_ShouldReturnValidResult()
+    {
+        // Act
+        var result = ValidationResult.Success;
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Failure_WithSingleError_ShouldReturnInvalidResult()
+    {
+        // Act
+        var result = ValidationResult.Failure("Username", "Username is required");
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().HaveCount(1);
+        result.Errors[0].PropertyName.Should().Be("Username");
+        result.Errors[0].ErrorMessage.Should().Be("Username is required");
+    }
+
+    [Fact]
+    public void Failure_WithMultipleErrors_ShouldReturnInvalidResult()
+    {
+		// Arrange 
+		var errors = new[]
+		{
+			new ValidationError("Username", "Username is required"),
+			new ValidationError("Email", "Email is invalid")
+		};
+
+        // Act
+		var result = ValidationResult.Failure(errors);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().HaveCount(2);
+        result.Errors[0].PropertyName.Should().Be("Username");
+        result.Errors[0].ErrorMessage.Should().Be("Username is required");
+        result.Errors[1].PropertyName.Should().Be("Email");
+        result.Errors[1].ErrorMessage.Should().Be("Email is invalid");
+	}
+
+    [Fact]
+    public void Constructor_WithNullErrors_ShouldReturnValidResult()
+    {
+        // Act
+        var result = new ValidationResult(null);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+	}
+
+    [Fact]
+    public void Constructor_WithEmptyErrors_ShouldReturnValidResult()
+    {
+        // Act
+        var result = new ValidationResult(Array.Empty<ValidationError>());
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+        result.Errors.Should().BeEmpty();
+	}
+}


### PR DESCRIPTION
## Add Built-in Validation Support

### Summary
This PR introduces a lightweight, opt-in validation system to Sinter, providing a simple way to validate requests before they reach handlers. The implementation maintains Sinter's performance-first philosophy while offering essential validation capabilities.

### What's New

#### Core Features
- **Validation Interfaces**: `IValidator<T>` for implementing request validators
- **Base Validator Class**: `AbstractValidator<T>` with fluent rule configuration
- **Built-in Validation Rules**: Common validators like Required, Email, MinLength, Range, etc.
- **Conditional Validation**: Support for `When()` and `Unless()` conditions
- **Async Validation**: Support for database lookups and external validation

#### Key Components
- `ValidationResult` and `ValidationError` for capturing validation outcomes
- `PropertyValidator<TRequest, TProperty>` for property-level validation
- `RuleBuilder<TRequest, TProperty>` for fluent API
- `ValidationRules` static class with reusable validation logic

### Usage Example
```csharp
public class CreateUserCommandValidator : AbstractValidator<CreateUserCommand>
{
    public CreateUserCommandValidator(IUserRepository repository)
    {
        RuleFor(x => x.Email)
            .Required()
            .Email()
            .MustAsync(async (email, ct) => !await repository.EmailExistsAsync(email, ct))
            .WithMessage("Email already exists");
            
        RuleFor(x => x.Age)
            .GreaterThanOrEqual(18)
            .LessThan(120);
            
        RuleFor(x => x.CompanyName)
            .Required()
            .When(x => x.UserType == UserType.Business);
    }
}

// Registration
services.AddSinter(assemblies);
services.AddSinterValidators(assemblies);